### PR TITLE
Update dependencies in setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,10 @@ setup(
         'matplotlib>=1.5',
         'rtree',
         'h5py',
+        'Shapely',
+        'openmdao',
+    ],
+    tests_require=[
         'pytest',
     ],
     package_data={

--- a/setup.py
+++ b/setup.py
@@ -27,9 +27,12 @@ setup(
         'rtree',
         'h5py',
         'Shapely',
-        'openmdao',
     ],
+    extras_require={
+        'mdao': ['openmdao']
+    }
     tests_require=[
+        'openmdao',
         'pytest',
     ],
     package_data={


### PR DESCRIPTION
Add missing dependencies: `Shapely` and `openmdao`.
Move `pytest` to tests_require.