### PR TITLE
Adding reference to BagProject object in make_template_db method

### DIFF
--- a/bag/core.py
+++ b/bag/core.py
@@ -598,7 +598,7 @@ class BagProject(object):
         routing_grid = RoutingGrid(self.tech_info, layers, spaces, widths, bot_dir,
                                    width_override=width_override)
         tdb = TemplateDB('template_libs.def', routing_grid, impl_lib, use_cybagoa=use_cybagoa,
-                         gds_lay_file=gds_lay_file, cache_dir=cache_dir)
+                         gds_lay_file=gds_lay_file, cache_dir=cache_dir, prj=self)
 
         return tdb
 


### PR DESCRIPTION
Currently the `self._prj` attribute in `TemplateDB` is None. This pull request properly fills it with the current `BagProject` object. This is useful in cases where BAG plugins would like easy access to `BagProject` and the included skill interface directly from within generator classes