### PR TITLE
Added new property to InstanceInfo master_key

### DIFF
--- a/bag/interface/skill.py
+++ b/bag/interface/skill.py
@@ -449,6 +449,10 @@ class SkillInterface(DbAccess):
         for info_list in layout_list:
             new_inst_list = []
             for inst in info_list[1]:
+                if 'master_key' in inst:
+                    # SKILL inteface cannot handle master_key info, so we remove it
+                    # from InstanceInfo if we find it
+                    inst.pop('master_key')
                 if 'params' in inst:
                     inst = inst.copy()
                     inst['params'] = _dict_to_pcell_params(inst['params'])

--- a/bag/layout/objects.py
+++ b/bag/layout/objects.py
@@ -253,7 +253,7 @@ class InstanceInfo(dict):
     """
 
     param_list = ['lib', 'cell', 'view', 'name', 'loc', 'orient', 'num_rows',
-                  'num_cols', 'sp_rows', 'sp_cols']
+                  'num_cols', 'sp_rows', 'sp_cols', 'master_key']
 
     def __init__(self, res, change_orient=True, **kwargs):
         kv_iter = ((key, kwargs[key]) for key in self.param_list)
@@ -353,6 +353,14 @@ class InstanceInfo(dict):
     def params(self, new_params):
         # type: (Optional[Dict[str, Any]]) -> None
         self['params'] = new_params
+
+    @property
+    def master_key(self):
+        return self.get('master_key', None)
+
+    @master_key.setter
+    def master_key(self, value):
+        self['master_key'] = value
 
     @property
     def angle_reflect(self):
@@ -633,6 +641,7 @@ class Instance(Arrayable):
                             num_cols=self.nx,
                             sp_rows=self.spy,
                             sp_cols=self.spx,
+                            master_key=self.master.key
                             )
 
     @property


### PR DESCRIPTION
## Purpose
It is currently difficult to find the master associated with any given instance in the content list. This would be useful when traversing and manipulating the content list for functions like hierarchy flattening.

## Solution
Added a new parameter `master_key` to the dictionary `InstanceInfo` which will contain the key for the master that it refers to. This enables methods in subclasses of `TemplateDB` to simply use `_master_lookup()` to find the master associated with an `InstanceInfo` and traverse the tree.

Also needed to modify `get_content()` for `Instances` to properly dump the master_key information into `InstanceInfo`