### PR TITLE
Prim inst fix

### DIFF
--- a/bag/layout/objects.py
+++ b/bag/layout/objects.py
@@ -253,16 +253,14 @@ class InstanceInfo(dict):
     """
 
     param_list = ['lib', 'cell', 'view', 'name', 'loc', 'orient', 'num_rows',
-                  'num_cols', 'sp_rows', 'sp_cols']
+                  'num_cols', 'sp_rows', 'sp_cols', 'master_key']
 
     def __init__(self, res, change_orient=True, **kwargs):
-        kv_iter = ((key, kwargs[key]) for key in self.param_list)
+        kv_iter = ((key, kwargs.get(key, None)) for key in self.param_list)
         dict.__init__(self, kv_iter)
         self._resolution = res
         if 'params' in kwargs:
             self.params = kwargs['params']
-        if 'master_key' in kwargs:
-            self.master_key = kwargs['master_key']
 
         # skill/OA array before rotation, while we're doing the opposite.
         # this is supposed to fix it.

--- a/bag/layout/objects.py
+++ b/bag/layout/objects.py
@@ -253,7 +253,7 @@ class InstanceInfo(dict):
     """
 
     param_list = ['lib', 'cell', 'view', 'name', 'loc', 'orient', 'num_rows',
-                  'num_cols', 'sp_rows', 'sp_cols', 'master_key']
+                  'num_cols', 'sp_rows', 'sp_cols']
 
     def __init__(self, res, change_orient=True, **kwargs):
         kv_iter = ((key, kwargs[key]) for key in self.param_list)
@@ -261,6 +261,8 @@ class InstanceInfo(dict):
         self._resolution = res
         if 'params' in kwargs:
             self.params = kwargs['params']
+        if 'master_key' in kwargs:
+            self.master_key = kwargs['master_key']
 
         # skill/OA array before rotation, while we're doing the opposite.
         # this is supposed to fix it.


### PR DESCRIPTION
`master_key` was an additional parameter used to make reverse lookup of masters from instances convenient. However, primitive instances directly create instance_info objects and don't have `master_key` information. To fix primitive instance support while enabling future extensions to the `InstanceInfo` protocol, I have switched to `kwargs.get(key, None)` instead of `kwargs[key]`