### PR TITLE
Modifying template base to deepcopy any passed in parameter dict

### DIFF
--- a/bag/layout/template.py
+++ b/bag/layout/template.py
@@ -1208,7 +1208,8 @@ class TemplateBase(DesignMaster, metaclass=abc.ABCMeta):
             the new template instance.
         """
         kwargs['grid'] = self.grid
-        return self.template_db.new_template(params=params, temp_cls=temp_cls, debug=debug,
+        template_params = copy.deepcopy(params)
+        return self.template_db.new_template(params=template_params, temp_cls=temp_cls, debug=debug,
                                              **kwargs)
 
     def move_all_by(self, dx=0.0, dy=0.0, unit_mode=False):


### PR DESCRIPTION
In some cases, users may have some base dictionary of parameters that they may modify on the fly and use to call `self.new_template()` in a generator. This parameter dictionary is passed by reference all the way through MasterDB. When the users modify the base dictionary, the database's cache also gets mutated, so subsequent calls end up using the previously cached value.

To fix this, I simply deep copy the parameter dict that the user provides when they call `self.new_template()`.

Sidney is currently making a test case to reproduce this issue and confirm that this fix does function as expected, please wait until this is confirmed to execute the pull request