### PR TITLE
Fix skill interface

### DIFF
--- a/bag/interface/skill.py
+++ b/bag/interface/skill.py
@@ -449,13 +449,13 @@ class SkillInterface(DbAccess):
         for info_list in layout_list:
             new_inst_list = []
             for inst in info_list[1]:
+                if 'params' in inst:
+                    inst = inst.copy()
+                    inst['params'] = _dict_to_pcell_params(inst['params'])
                 if 'master_key' in inst:
                     # SKILL inteface cannot handle master_key info, so we remove it
                     # from InstanceInfo if we find it
                     inst.pop('master_key')
-                if 'params' in inst:
-                    inst = inst.copy()
-                    inst['params'] = _dict_to_pcell_params(inst['params'])
                 new_inst_list.append(inst)
 
             new_info_list = info_list[:]


### PR DESCRIPTION
@ayan-biswas : In class SkillInterface(DbAccess)
If you provide parameters for primitive instance, the master:key was not
removed, which caused skill interface to fail. This fixes it.